### PR TITLE
patch array indexing

### DIFF
--- a/examples/cluttered_flight/test.py
+++ b/examples/cluttered_flight/test.py
@@ -19,7 +19,6 @@ class Test(TestBase):
         print("Shape of state_data:", state_data.shape)  # Debugging line
 
         t = np.array(self.t)
-        print("Shape of self.t:", t.shape)  # Debugging line
 
         if t.ndim == 1:
             t = t  # No need to index if it's already 1D


### PR DESCRIPTION
array `t` is one dimensional, however we are trying to access it as if it has two dimensions, I fixed this issue, by just handling the array t dynamically based on its dimension. If `t` is guaranteed to be single dimensional then further check is not needed.