### PR TITLE
Fix BPTT autograd inplace errors in Dynamics.reset and Integrator.integrate

### DIFF
--- a/envs/base/dynamics.py
+++ b/envs/base/dynamics.py
@@ -246,25 +246,35 @@ class Dynamics:
                 self._quad_drag_coeffs = self._quad_drag_coeffs_mean * (((th.rand_like(self._quad_drag_coeffs_mean)-0.5)*2*self._drag_random).clamp(-0.5, .5) + 1)
 
         else:
-            self._position[:, indices] = th.zeros((3, len(indices)), device=self.device) if pos is None else pos.T
-            self._orientation[indices] = Quaternion(num=len(indices), device=self.device) if ori is None else Quaternion(*ori.T)
-            self._velocity[:, indices] = th.zeros((3, len(indices)), device=self.device) if vel is None else vel.T
-            self._angular_velocity[:, indices] = th.zeros((3, len(indices)), device=self.device) if ori_vel is None else ori_vel.T
-            self._motor_omega[:, indices] = th.ones((4, len(indices)), device=self.device) * self._init_motor_omega if motor_omega is None else motor_omega.T
-            self._thrusts[:, indices] = th.ones((4, len(indices)), device=self.device) * self._init_thrust if thrusts is None else thrusts.T
-            self._t[indices] = th.zeros((len(indices),), device=self.device) if t is None else t
-            self._t[indices] = th.zeros((len(indices),), device=self.device) + th.rand((len(indices),)) * 3.14*2 if t is None else t
-            # self._ctrl_i[:, indices] = th.zeros((3, len(indices)), device=self.device)
-            self._angular_acc[:, indices] = th.zeros((3, len(indices)), device=self.device)
-            self._acc[:, indices] = th.zeros((3, len(indices)), device=self.device)
-            self._acc_z_body[:, indices] = th.zeros((1, len(indices)), device=self.device)
-            self._dacc_z_body[:, indices] = th.zeros((1, len(indices)), device=self.device)
-            for i in range(self._comm_delay_steps):
-                self._pre_action[i][:, indices] = self._pre_action[i][:, indices] * 0
-            
+            # Functional ``index_copy``: rebinding ``self._*`` to a fresh
+            # tensor never bumps the autograd version of the tensor the
+            # BPTT backward graph still holds as a saved view.
+            # ``cp`` aligns ``idx`` and ``src`` to the buffer's own device so
+            # this works even when individual buffers (e.g. ``_pre_action``)
+            # were created without ``device=self.device`` or when the caller
+            # passes a CPU ``indices`` tensor while buffers live on cuda.
+            n = len(indices)
+            idx = th.as_tensor(indices).long()
+            z3, z4, z1 = (th.zeros((d, n), device=self.device) for d in (3, 4, 1))
+            cp = lambda buf, src, dim=1: buf.index_copy(dim, idx.to(buf.device), src.to(buf.device))
+
+            self._position         = cp(self._position,         pos.T     if pos     is not None else z3)
+            self._velocity         = cp(self._velocity,         vel.T     if vel     is not None else z3)
+            self._angular_velocity = cp(self._angular_velocity, ori_vel.T if ori_vel is not None else z3)
+            self._motor_omega      = cp(self._motor_omega, motor_omega.T if motor_omega is not None else z4 + self._init_motor_omega)
+            self._thrusts          = cp(self._thrusts,     thrusts.T     if thrusts     is not None else z4 + self._init_thrust)
+            self._angular_acc      = cp(self._angular_acc, z3)
+            self._acc              = cp(self._acc,         z3)
+            self._acc_z_body       = cp(self._acc_z_body,  z1)
+            self._dacc_z_body      = cp(self._dacc_z_body, z1)
+            self._t                = cp(self._t, t if t is not None else th.rand(n, device=self.device) * 3.14 * 2, dim=0)
+            self._orientation[indices] = Quaternion(num=n, device=self.device) if ori is None else Quaternion(*ori.T)
+            self._pre_action       = [cp(pa, th.zeros((4, n), device=self.device)) for pa in self._pre_action]
+
             if self._drag_random:
-                self._linear_drag_coeffs[:, indices] = self._linear_drag_coeffs_mean * (((th.rand_like(self._linear_drag_coeffs_mean[:,indices])-0.5)*2*self._drag_random).clamp(-0.5, .5) + 1)
-                self._quad_drag_coeffs[:, indices] = self._quad_drag_coeffs_mean * (((th.rand_like(self._quad_drag_coeffs_mean[:,indices])-0.5)*2*self._drag_random).clamp(-0.5, .5) + 1)
+                jitter = lambda mean: mean[:, idx] * (((th.rand_like(mean[:, idx]) - 0.5) * 2 * self._drag_random).clamp(-0.5, 0.5) + 1)
+                self._linear_drag_coeffs = cp(self._linear_drag_coeffs, jitter(self._linear_drag_coeffs_mean))
+                self._quad_drag_coeffs   = cp(self._quad_drag_coeffs,   jitter(self._quad_drag_coeffs_mean))
 
         return self.state
 

--- a/utils/maths.py
+++ b/utils/maths.py
@@ -341,12 +341,13 @@ class Integrator:
                 J_inv=J_inv,
                 wind=wind,
             )
-            pos += d_pos * dt
-            ori += d_ori * dt
-            vel += d_vel * dt
-            ori_vel += d_ori_vel * dt
-
-            # ori = ori / ori.norm()
+            # Functional (not in-place): += bumps the autograd version of
+            # the tensor passed in, which breaks BPTT backward when rewards
+            # saved a view into it (``self.position = self._position.T``).
+            pos = pos + d_pos * dt
+            ori = ori + d_ori * dt
+            vel = vel + d_vel * dt
+            ori_vel = ori_vel + d_ori_vel * dt
 
             return pos, ori, vel, ori_vel, d_ori_vel
 
@@ -378,10 +379,11 @@ class Integrator:
                         J_inv=J_inv
                     )
             # f"w_cache: {ori_vel_cache} quat:{ori_cache} d_ori:{d_ori[:,:,index]}"
-            pos += d_pos @ ks * dt
-            ori += d_ori @ ks * dt
-            vel += d_vel @ ks * dt
-            ori_vel += d_ori_vel @ ks * dt
+            # Functional (not in-place); see euler branch for rationale.
+            pos = pos + d_pos @ ks * dt
+            ori = ori + d_ori @ ks * dt
+            vel = vel + d_vel @ ks * dt
+            ori_vel = ori_vel + d_ori_vel @ ks * dt
 
             return pos, ori, vel, ori_vel, d_ori_vel
 


### PR DESCRIPTION
## Summary

Two in-place mutations in the simulator touch tensors that BPTT
reward/observation code has already saved as views into the backward
graph, which makes `actor_loss.backward()` fail with:

```
RuntimeError: one of the variables needed for gradient computation has been
modified by an inplace operation: [torch.FloatTensor [N, 3]], which is
output 0 of AsStridedBackward0, is at version 1; expected version 0 instead.
```

Either mutation alone is enough to invalidate saved views from earlier
rollout steps; both need fixing for BPTT rollouts that hit early-done
events (collision / out-of-bounds / timeout).

## Root cause

1. **`Dynamics.reset(indices=...)`** (partial-reset branch) rewrites
   `self._position[:, indices] = ...` (and the same for `_velocity`,
   `_angular_velocity`, `_motor_omega`, `_thrusts`, `_acc*`, `_t`,
   `_pre_action`, `_linear_drag_coeffs`, `_quad_drag_coeffs`), bumping the
   storage's autograd version counter.
2. **`Integrator.integrate`** (both `euler` and `rk4` branches) uses
   `pos += d_pos * dt` etc. The `+=` is an in-place add on the caller's
   tensor (the same `self._position` that reward functions read via
   `self.position = self._position.T`).

In a BPTT rollout, reward code typically does something like
`(self.position - self.target).norm(dim=1)`, which autograd saves with
an `AsStridedBackward0` node pointing at `self._position`'s storage.
The next simulator step bumps that storage's version, and the final
`loss.backward()` fails the version check.

## Fix

- `Dynamics.reset(indices=...)`: rebind state tensors with
  `torch.Tensor.index_copy(dim, idx, src)` (functional; returns a new
  tensor). `self._*` then points at a fresh tensor, so the previous
  tensor kept alive by the backward graph is never mutated.
- `Integrator.integrate`: replace `x += y` with `x = x + y` for
  `pos / ori / vel / ori_vel` in both `euler` and `rk4` branches.

## Impact

- **Numerical parity**: verified bit-for-bit identical forward outputs
  (state, reward, loss) and backward gradients against the unpatched
  implementation on scenarios the unpatched code can run. Where the
  unpatched code crashes, the patched version completes.
- **No API changes**.
- **PPO / SAC unchanged** (they don't backward through the simulator,
  so they never trigger the crash and behave identically).
- **Memory overhead**: one extra tensor allocation per reset per state
  field, and per integrator call. Negligible in practice.

## Repro / verification

With the unpatched repo, running BPTT on `HoverEnv` with a
randomly-initialized policy and `num_agent_per_scene=100`,
`ctrl_delay=True`, `horizon=96`, crashes the first `actor_loss.backward()`
100% of the time.

After this patch, a stress test with a deliberately chaotic policy that
triggers ~280 `dynamics.reset(indices=...)` events per rollout completes
5/5 rollouts with sensible gradients:

```
epoch 0: HORIZON=96 done_events= 286 loss=24949.53 |grad|=32369.4   OK
epoch 1: HORIZON=96 done_events= 280 loss=26892.68 |grad|=81426.6   OK
epoch 2: HORIZON=96 done_events= 250 loss=28862.98 |grad|=166099.7  OK
epoch 3: HORIZON=96 done_events= 284 loss=26652.84 |grad|=209142.6  OK
epoch 4: HORIZON=96 done_events= 276 loss=25854.06 |grad|=252350.0  OK
```

## Test plan

- [x] Unit-style minimal repro reproduces the crash on `beta` HEAD and
      passes after the patch.
- [x] Forward / backward numerical parity vs. unpatched code on
      scenarios that don't crash (all deltas are 0.000e+00).
- [x] Full BPTT rollout with real `hover.yaml` config + chaotic policy
      completes without crashing.